### PR TITLE
[feature]  support system-role 

### DIFF
--- a/superchat.el
+++ b/superchat.el
@@ -14,6 +14,9 @@
 (require 'gptel-context nil t)
 (require 'superchat-memory)
 
+(defvar system-role nil
+  "Dynamic binding used by GPT backends; defined here to avoid void-variable errors.")
+
 (declare-function superchat-memory-compose-title "superchat-memory" (content))
 (declare-function superchat-memory-capture-explicit "superchat-memory" (content &optional title))
 (declare-function superchat-memory-capture-conversation "superchat-memory" (content &rest options))

--- a/superchat.el
+++ b/superchat.el
@@ -99,7 +99,7 @@ Only files with these extensions are shown in the file picker."
 
 (defcustom superchat-general-answer-prompt
   (string-join
-   '("You are a helpful assistant. Please provide a clear and comprehensive answer to the user's question: $input")
+   '("Please provide a clear and comprehensive answer to the user's question: $input")
    "\n")
   "The prompt template used for general questions."
   :type 'string


### PR DESCRIPTION
Introduced editable system role functionality for Superchat. The chat buffer now automatically generates a `* System:` node, where the text content is sent as a system message with each gptel call, no longer mixed with regular prompts.

Users can edit directly in the Org buffer or run `M-x superchat-set-system-role` for quick modifications. The top header displays the current role name and prefix content in
italics, making the status immediately visible.

This approach provides two key benefits:

First, it extracts persistent instructions like "who you are and how you should speak" from prompt templates, enabling independent management;

Second, it allows users to adjust roles per session (e.g., setting it to "You are an Emacs technical expert") while preserving custom commands that supplement variables like
`$input` only at the user message level. Overall, this makes default prompts more concise while turning system roles into true configuration items, with a clear and controllable implementation approach.
